### PR TITLE
Use UTF-8 when reading __init__.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import versioneer
 
 # Read author etc. from __init__.py
-for line in open('pydna/__init__.py'):
+for line in open('pydna/__init__.py', encoding="utf-8"):
     if line.startswith('__') and not line.startswith('__version') and not line.startswith('__long'):
         exec(line.strip())
 


### PR DESCRIPTION
This change fixes an encoding error I encountered on macOS Python 3.6 while updating the pydna bioconda package:

Full build log: https://circleci.com/gh/bioconda/bioconda-recipes/2242

```
06:27:51 BIOCONDA ERROR STDOUT+STDERR:
+ source /tmp/workspace/miniconda/bin/activate /tmp/workspace/miniconda/conda-bld/pydna_1518445616469/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla
+ /tmp/workspace/miniconda/conda-bld/pydna_1518445616469/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/bin/python setup.py install --single-version-externally-managed --record=record.txt
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    for line in open('pydna/__init__.py'):
  File "/tmp/workspace/miniconda/conda-bld/pydna_1518445616469/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 470: ordinal not in range(128)
```