### PR TITLE
Add missing utf8-encodings in dseqrecord

### DIFF
--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -577,10 +577,10 @@ class Dseqrecord(_SeqRecord):
                 newobj = _copy.copy(self)
                 newobj.description = newdescription
 
-                with open(filename, "w") as fp:
+                with open(filename, "w", encoding="utf8") as fp:
                     fp.write(newobj.format(f))
             else:
-                with open(filename, "w") as fp:
+                with open(filename, "w", encoding="utf8") as fp:
                     fp.write(self.format(f))
         #from IPython.display import display_markdown
         #return display_markdown("[link](ling.gb)",raw=True)

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -527,7 +527,7 @@ class Dseqrecord(_SeqRecord):
         name, ext = _os.path.splitext(filename)
         msg = f"<font face=monospace><a href='{filename}' target='_blank'>{filename}</a></font><br>"
         if not _os.path.isfile(filename):
-            with open(filename, "w") as fp:
+            with open(filename, "w", encoding="utf8") as fp:
                 fp.write(self.format(f))
         else:
             from pydna.readers import read
@@ -559,7 +559,7 @@ class Dseqrecord(_SeqRecord):
                     ntop={True: "-", False: "o"}[self.linear],
                     otop={True: "-", False: "o"}[old_file.linear],
                 )
-                with open(filename, "w") as fp:
+                with open(filename, "w", encoding="utf8") as fp:
                     fp.write(self.format(f))
             elif "SEGUID" in old_file.description:
                 pattern = r"(lSEGUID|cSEGUID|SEGUID)_(\S{27})(_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}){0,1}"


### PR DESCRIPTION
I was still getting the error after commit https://github.com/BjornFJohansson/pydna/commit/58de04def891e8dc36056b8760510398fcc47496. I realized that some utf8 encodings were missing when using open in dseqrecord. This fixes issue #71