### PR TITLE
Make Amplicons more compatible with Fasta export

### DIFF
--- a/src/pydna/amplify.py
+++ b/src/pydna/amplify.py
@@ -405,11 +405,11 @@ class Anneal(object, metaclass=_Memoize):
                 prd.id = (
                     _identifier_from_string(new_identifier)[:16]
                     or self.kwargs.get("id")
-                    or "{}bp {}".format(str(len(prd))[:14], prd.seguid())
+                    or "{}bp_{}".format(str(len(prd))[:14], prd.seguid())
                 )
                 prd.description = self.kwargs.get(
                     "description"
-                ) or "pcr product_{}_{}".format(fp.description, rp.description)
+                ) or "pcr_product_{}_{}".format(fp.description, rp.description)
 
                 amplicon = _Amplicon(
                     prd,


### PR DESCRIPTION
This is a really small change. I added underscores in the 'id' and 'description' fields of products of Anneal. This ensures that the ID will remain the same when these products are written to Fasta and re-parsed. Previously, the space in the ID field meant that the seguid portion of the ID was lost when the Fasta file was re-parsed.