### PR TITLE
Issue 157

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ docs/_build/
 target/
 
 .eggs
+
+# mac files
+.DS_Store

--- a/poetry.lock
+++ b/poetry.lock
@@ -1288,17 +1288,6 @@ files = [
 traitlets = "*"
 
 [[package]]
-name = "more-itertools"
-version = "10.1.0"
-description = "More routines for operating on iterables, beyond itertools"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "more-itertools-10.1.0.tar.gz", hash = "sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a"},
-    {file = "more_itertools-10.1.0-py3-none-any.whl", hash = "sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6"},
-]
-
-[[package]]
 name = "nbformat"
 version = "5.9.2"
 description = "The Jupyter Notebook format"
@@ -2599,4 +2588,4 @@ gel = ["matplotlib", "pillow", "scipy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "bbe87d96b3360fc1aca076e1d1c33c9a31b5313b2602a4be5ba4fc597e228aea"
+content-hash = "f9116f198349f8f2ea56eed13d222b048cbb2eeeb24363c01ae8a5e469341e14"

--- a/poetry.lock
+++ b/poetry.lock
@@ -380,6 +380,7 @@ files = [
     {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18a64814ae7bce73925131381603fff0116e2df25230dfc80d6d690aa6e20b37"},
     {file = "contourpy-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c81f22b4f572f8a2110b0b741bb64e5a6427e0a198b2cdc1fbaf85f352a3aa"},
     {file = "contourpy-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53cc3a40635abedbec7f1bde60f8c189c49e84ac180c665f2cd7c162cc454baa"},
+    {file = "contourpy-1.1.0-cp310-cp310-win32.whl", hash = "sha256:9b2dd2ca3ac561aceef4c7c13ba654aaa404cf885b187427760d7f7d4c57cff8"},
     {file = "contourpy-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:1f795597073b09d631782e7245016a4323cf1cf0b4e06eef7ea6627e06a37ff2"},
     {file = "contourpy-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0b7b04ed0961647691cfe5d82115dd072af7ce8846d31a5fac6c142dcce8b882"},
     {file = "contourpy-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27bc79200c742f9746d7dd51a734ee326a292d77e7d94c8af6e08d1e6c15d545"},
@@ -388,6 +389,7 @@ files = [
     {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5cec36c5090e75a9ac9dbd0ff4a8cf7cecd60f1b6dc23a374c7d980a1cd710e"},
     {file = "contourpy-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f0cbd657e9bde94cd0e33aa7df94fb73c1ab7799378d3b3f902eb8eb2e04a3a"},
     {file = "contourpy-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:181cbace49874f4358e2929aaf7ba84006acb76694102e88dd15af861996c16e"},
+    {file = "contourpy-1.1.0-cp311-cp311-win32.whl", hash = "sha256:edb989d31065b1acef3828a3688f88b2abb799a7db891c9e282df5ec7e46221b"},
     {file = "contourpy-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb3b7d9e6243bfa1efb93ccfe64ec610d85cfe5aec2c25f97fbbd2e58b531256"},
     {file = "contourpy-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bcb41692aa09aeb19c7c213411854402f29f6613845ad2453d30bf421fe68fed"},
     {file = "contourpy-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5d123a5bc63cd34c27ff9c7ac1cd978909e9c71da12e05be0231c608048bb2ae"},
@@ -396,6 +398,7 @@ files = [
     {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:317267d915490d1e84577924bd61ba71bf8681a30e0d6c545f577363157e5e94"},
     {file = "contourpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d551f3a442655f3dcc1285723f9acd646ca5858834efeab4598d706206b09c9f"},
     {file = "contourpy-1.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e7a117ce7df5a938fe035cad481b0189049e8d92433b4b33aa7fc609344aafa1"},
+    {file = "contourpy-1.1.0-cp38-cp38-win32.whl", hash = "sha256:108dfb5b3e731046a96c60bdc46a1a0ebee0760418951abecbe0fc07b5b93b27"},
     {file = "contourpy-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:d4f26b25b4f86087e7d75e63212756c38546e70f2a92d2be44f80114826e1cd4"},
     {file = "contourpy-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc00bb4225d57bff7ebb634646c0ee2a1298402ec10a5fe7af79df9a51c1bfd9"},
     {file = "contourpy-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:189ceb1525eb0655ab8487a9a9c41f42a73ba52d6789754788d1883fb06b2d8a"},
@@ -404,6 +407,7 @@ files = [
     {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:143dde50520a9f90e4a2703f367cf8ec96a73042b72e68fcd184e1279962eb6f"},
     {file = "contourpy-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e94bef2580e25b5fdb183bf98a2faa2adc5b638736b2c0a4da98691da641316a"},
     {file = "contourpy-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ed614aea8462735e7d70141374bd7650afd1c3f3cb0c2dbbcbe44e14331bf002"},
+    {file = "contourpy-1.1.0-cp39-cp39-win32.whl", hash = "sha256:71551f9520f008b2950bef5f16b0e3587506ef4f23c734b71ffb7b89f8721999"},
     {file = "contourpy-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:438ba416d02f82b692e371858143970ed2eb6337d9cdbbede0d8ad9f3d7dd17d"},
     {file = "contourpy-1.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a698c6a7a432789e587168573a864a7ea374c6be8d4f31f9d87c001d5a843493"},
     {file = "contourpy-1.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:397b0ac8a12880412da3551a8cb5a187d3298a72802b45a3bd1805e204ad8439"},
@@ -1282,6 +1286,17 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "more-itertools"
+version = "10.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "more-itertools-10.1.0.tar.gz", hash = "sha256:626c369fa0eb37bac0291bce8259b332fd59ac792fa5497b59837309cd5b114a"},
+    {file = "more_itertools-10.1.0-py3-none-any.whl", hash = "sha256:64e0735fcfdc6f3464ea133afe8ea4483b1c5fe3a3d69852e6503b43a0b222e6"},
+]
 
 [[package]]
 name = "nbformat"
@@ -2584,4 +2599,4 @@ gel = ["matplotlib", "pillow", "scipy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "f9116f198349f8f2ea56eed13d222b048cbb2eeeb24363c01ae8a5e469341e14"
+content-hash = "bbe87d96b3360fc1aca076e1d1c33c9a31b5313b2602a4be5ba4fc597e228aea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pillow = { version = ">=8.4.0", optional = true }
 pyparsing = { version = ">=2.4.7", optional = true }
 requests = { version = ">=2.26.0", optional = true }
 cai2 = { version = ">=1.0.5", optional = true }
+more-itertools = "^10.1.0"
 [tool.poetry.extras]
 clipboard = ["pyperclip"]
 gel = ["scipy", "matplotlib", "pillow"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ pillow = { version = ">=8.4.0", optional = true }
 pyparsing = { version = ">=2.4.7", optional = true }
 requests = { version = ">=2.26.0", optional = true }
 cai2 = { version = ">=1.0.5", optional = true }
-more-itertools = "^10.1.0"
 [tool.poetry.extras]
 clipboard = ["pyperclip"]
 gel = ["scipy", "matplotlib", "pillow"]

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1502,8 +1502,8 @@ class Dseq(_Seq):
         Special cases:
         - Single cutsite on circular sequence: returns a pair where both cutsites are the same
         - Linear sequence:
-            - creates a new left_cut on the first pair to represent the left edge of the sequence as it is.
-            - creates a new right_cut on the last pair to represent the right edge of the sequence as it is.
+            - creates a new left_cut on the first pair equal to `None` to represent the left edge of the sequence as it is.
+            - creates a new right_cut on the last pair equal to `None` to represent the right edge of the sequence as it is.
             - In both new cuts, the enzyme is set to None to indicate that the cut is not made by an enzyme.
 
         Parameters
@@ -1512,7 +1512,7 @@ class Dseq(_Seq):
 
         Returns
         -------
-        list[tuple[tuple[tuple[int,int], _RestrictionType]],tuple[tuple[int,int], _RestrictionType]]
+        list[tuple[tuple[tuple[int,int], _RestrictionType]|None],tuple[tuple[int,int], _RestrictionType]|None]
 
         Examples
         --------

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1480,7 +1480,7 @@ class Dseq(_Seq):
     def apply_cut(self, left_cut, right_cut):
 
         left_watson, left_crick = left_cut[0]
-        ovhg = 0 if left_cut[1] is None else left_cut[1].ovhg
+        ovhg = self.ovhg if left_cut[1] is None else left_cut[1].ovhg
         right_watson, right_crick = right_cut[0]
         return Dseq(
                     str(self[left_watson:right_watson]),
@@ -1495,7 +1495,7 @@ class Dseq(_Seq):
         if len(cutsites) == 1 and self.circular:
             return [(cutsites[0], cutsites[0])]
         if not self.circular:
-            left_edge = ((0 if self.ovhg < 0 else self.ovhg, 0 if self.ovhg < 0 else -self.ovhg), None)
+            left_edge = ((self.ovhg, 0) if self.ovhg > 0 else (0, -self.ovhg), None)
             right_edge = ((left_edge[0][0] + len(self.watson), left_edge[0][1] + len(self.crick)), None)
             cutsites = [left_edge, *cutsites, right_edge]
         else:

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1443,114 +1443,65 @@ class Dseq(_Seq):
 
         """
 
-        pad = "n" * 50
+        cutsites = self.get_cutsites(*enzymes)
+        cutsite_pairs = self.get_cutsite_pairs(cutsites)
+        return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)
 
-        if self.circular:
-            dsseq = Dseq.from_string(
-                self._data.decode("ASCII"),
-                # linear=True,
-                circular=False,
-            )
-        else:
-            dsseq = self.mung()
+    def get_cutsites(self, *enzymes):
+        """Returns a list of cutsites, represented by tuples ((cut_watson, cut_crick), enzyme).
 
-        if len(enzymes) == 1 and hasattr(enzymes[0], "intersection"):
-            # argument is probably a RestrictionBatch
-            enzymecuts = []
-            for e in enzymes[0]:
-                cuts = e.search(_Seq(pad + dsseq.watson + dsseq.watson[: e.size - 1] + pad) if self.circular else dsseq)
-                enzymecuts.append((cuts, e))
-            enzymecuts.sort()
-            enzymes = [e for (c, e) in enzymecuts if c]
-        else:
-            # argument is probably a list of restriction enzymes
-            enzymes = [
-                e
-                for e in list(dict.fromkeys(_flatten(enzymes)))
-                if e.search(_Seq(pad + dsseq.watson + dsseq.watson[: e.size - 1] + pad) if self.circular else dsseq)
-            ]  # flatten
+        Parameters
+        ----------
 
-        if not enzymes:
-            return ()
+        enzymes : Union[_RestrictionBatch,list[_RestrictionType]]
 
+        Returns
+        -------
+        list[tuple[tuple[int,int], _RestrictionType]]
+
+        TODO: check that the cutsite does not fall on the ovhg
+        """
+
+        if len(enzymes) == 1 and isinstance(enzymes[0], _RestrictionBatch):
+                # argument is probably a RestrictionBatch
+                enzymes = [e for e in enzymes[0]]
+
+        enzymes = _flatten(enzymes)
+        out = list()
+        for e in enzymes:
+            # Positions are 1-based, so we subtract 1 to get 0-based positions
+            cuts_watson = [c - 1 for c in e.search(self, linear=(not self.circular))]
+            cuts_crick = [(c - e.ovhg) % len(self) for c in cuts_watson]
+
+            out += [((w, c), e) for w, c in zip(cuts_watson, cuts_crick)]
+
+        return sorted(out)
+
+    def apply_cut(self, left_cut, right_cut):
+
+        left_watson, left_crick = left_cut[0]
+        ovhg = 0 if left_cut[1] is None else left_cut[1].ovhg
+        right_watson, right_crick = right_cut[0]
+        return Dseq(
+                    str(self[left_watson:right_watson]),
+                    _rc(str(self[left_crick:right_crick])),
+                    ovhg=ovhg,
+                )
+
+    def get_cutsite_pairs(self, cutsites):
+        if len(cutsites) == 0:
+            return []
+        if len(cutsites) == 1 and self.circular:
+            return [(cutsites[0], cutsites[0])]
         if not self.circular:
-            frags = [self]
+            cutsites = [((0, 0), None), *cutsites, ((len(self), len(self)), None)]
         else:
-            ln = len(self)
-            for e in enzymes:
-                wpos = [x - len(pad) - 1 for x in e.search(_Seq(pad + self.watson + self.watson[: e.size - 1]) + pad)][
-                    ::-1
-                ]
-                cpos = [x - len(pad) - 1 for x in e.search(_Seq(pad + self.crick + self.crick[: e.size - 1]) + pad)][
-                    ::-1
-                ]
+            # Return in the same order as previous pydna versions
+            cutsites = [cutsites[-1]] + cutsites[:-1]
+            # Add the first cutsite at the end, for circular cuts
+            cutsites.append(cutsites[0])
 
-                for w, c in _itertools.product(wpos, cpos):
-                    if w % len(self) == (self.length - c + e.ovhg) % len(self):
-                        frags = [
-                            Dseq(
-                                self.watson[w % ln :] + self.watson[: w % ln],
-                                self.crick[c % ln :] + self.crick[: c % ln],
-                                ovhg=e.ovhg,
-                                pos=min(w, len(dsseq) - c),
-                            )
-                        ]
-                        # breakpoint()
-                        break
-                else:
-                    continue
-                break
-
-        newfrags = []
-
-        # print(repr(frags[0]))
-        # print(frags[0].pos)
-
-        for enz in enzymes:
-            for frag in frags:
-                ws = [x - 1 for x in enz.search(_Seq(frag.watson + "n"))]
-                cs = [x - 1 for x in enz.search(_Seq(frag.crick + "n"))]
-
-                sitepairs = [
-                    (sw, sc)
-                    for sw, sc in _itertools.product(ws, cs[::-1])
-                    if (
-                        sw + max(0, frag.ovhg) - max(0, enz.ovhg)
-                        == len(frag.crick) - sc - min(0, frag.ovhg) + min(0, enz.ovhg)
-                    )
-                ]
-
-                sitepairs.append((self.length, 0))
-
-                w2, c1 = sitepairs[0]
-                newfrags.append(Dseq(frag.watson[:w2], frag.crick[c1:], ovhg=frag.ovhg, pos=frag.pos))
-
-                for (w1, c2), (w2, c1) in zip(sitepairs[:-1], sitepairs[1:]):
-                    newfrags.append(
-                        Dseq(
-                            frag.watson[w1:w2],
-                            frag.crick[c1:c2],
-                            ovhg=enz.ovhg,
-                            pos=frag.pos + w1 - max(0, enz.ovhg) + max(0, frag.ovhg),
-                        )
-                    )
-            frags = newfrags
-            newfrags = []
-
-        return tuple(frags)
-
-    def _firstcut(self, *enzymes):
-        rb = _RestrictionBatch(_flatten(enzymes))
-        watson = _FormattedSeq(_Seq(self.watson), linear=False)
-        crick = _FormattedSeq(_Seq(self.crick), linear=False)
-        enzdict = dict(sorted(rb.search(watson).items(), key=_itemgetter(1)))
-        ln = self.length
-        for enzyme, wposlist in enzdict.items():
-            for cpos in enzyme.search(crick)[::-1]:
-                for wpos in wposlist:
-                    if cpos == (ln - wpos + enzyme.ovhg + 2) or ln:
-                        return (wpos - 1, cpos - 1, enzyme.ovhg)
-        return ()
+        return list(_itertools.pairwise(cutsites))
 
 
 if __name__ == "__main__":

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1482,8 +1482,6 @@ class Dseq(_Seq):
         left_watson, left_crick = left_cut[0]
         ovhg = 0 if left_cut[1] is None else left_cut[1].ovhg
         right_watson, right_crick = right_cut[0]
-        # TODO: this fills up nucleotides when it should not. It should either use the watson and crick
-        #      sequences as they are, or use the ovhg to shift the start or finish.
         return Dseq(
                     str(self[left_watson:right_watson]),
                     # The line below could be easier to understand as _rc(str(self[left_crick:right_crick])), but it does not preserve the case
@@ -1502,7 +1500,7 @@ class Dseq(_Seq):
             cutsites = [left_edge, *cutsites, right_edge]
         else:
             # Return in the same order as previous pydna versions
-            cutsites = [cutsites[-1]] + cutsites[:-1]
+            # cutsites = [cutsites[-1]] + cutsites[:-1]
             # Add the first cutsite at the end, for circular cuts
             cutsites.append(cutsites[0])
 

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1486,9 +1486,9 @@ class Dseq(_Seq):
 
     def apply_cut(self, left_cut, right_cut):
 
-        left_watson, left_crick = left_cut[0]
-        ovhg = self.ovhg if left_cut[1] is None else left_cut[1].ovhg
-        right_watson, right_crick = right_cut[0]
+        left_watson, left_crick = left_cut[0] if left_cut is not None else ((self.ovhg, 0) if self.ovhg > 0 else (0, -self.ovhg))
+        ovhg = self.ovhg if left_cut is None else left_cut[1].ovhg
+        right_watson, right_crick = right_cut[0] if right_cut is not None else (len(self.watson), len(self.crick))
         return Dseq(
                     str(self[left_watson:right_watson]),
                     # The line below could be easier to understand as _rc(str(self[left_crick:right_crick])), but it does not preserve the case
@@ -1521,7 +1521,7 @@ class Dseq(_Seq):
         >>> from pydna.dseq import Dseq
         >>> seq = Dseq('AAGAATTCAAGAATTC')
         >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
-        [(((0, 0), None), ((3, 7), EcoRI)), (((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((16, 16), None))]
+        [(None, ((3, 7), EcoRI)), (((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), None)]
         >>> seq = Dseq('AAGAATTCAAGAATTC', circular=True)
         >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
         [(((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((3, 7), EcoRI))]
@@ -1532,9 +1532,7 @@ class Dseq(_Seq):
         if len(cutsites) == 0:
             return []
         if not self.circular:
-            left_edge = ((self.ovhg, 0) if self.ovhg > 0 else (0, -self.ovhg), None)
-            right_edge = ((left_edge[0][0] + len(self.watson), left_edge[0][1] + len(self.crick)), None)
-            cutsites = [left_edge, *cutsites, right_edge]
+            cutsites = [None, *cutsites, None]
         else:
             # Add the first cutsite at the end, for circular cuts
             cutsites.append(cutsites[0])

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -33,8 +33,6 @@ from pydna.common_sub_strings import common_sub_strings as _common_sub_strings
 
 from Bio.Restriction import RestrictionBatch as _RestrictionBatch
 from Bio.Restriction import CommOnly
-# Pairwise only exists in normal itertools after python 3.10
-from more_itertools import pairwise as _pairwise
 
 
 class Dseq(_Seq):
@@ -1541,7 +1539,7 @@ class Dseq(_Seq):
             # Add the first cutsite at the end, for circular cuts
             cutsites.append(cutsites[0])
 
-        return list(_pairwise(cutsites))
+        return list(zip(cutsites, cutsites[1:]))
 
 
 if __name__ == "__main__":

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -22,7 +22,6 @@ import sys as _sys
 import math as _math
 
 from pydna.seq import Seq as _Seq
-from Bio.Restriction import FormattedSeq as _FormattedSeq
 from Bio.Seq import _translate_str
 
 from pydna._pretty import pretty_str as _pretty_str
@@ -32,9 +31,10 @@ from pydna.utils import rc as _rc
 from pydna.utils import flatten as _flatten
 from pydna.common_sub_strings import common_sub_strings as _common_sub_strings
 
-from operator import itemgetter as _itemgetter
 from Bio.Restriction import RestrictionBatch as _RestrictionBatch
 from Bio.Restriction import CommOnly
+# Pairwise only exists in normal itertools after python 3.10
+from more_itertools import pairwise as _pairwise
 
 
 class Dseq(_Seq):
@@ -1506,7 +1506,7 @@ class Dseq(_Seq):
             # Add the first cutsite at the end, for circular cuts
             cutsites.append(cutsites[0])
 
-        return list(_itertools.pairwise(cutsites))
+        return list(_pairwise(cutsites))
 
 
 if __name__ == "__main__":

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1482,9 +1482,12 @@ class Dseq(_Seq):
         left_watson, left_crick = left_cut[0]
         ovhg = 0 if left_cut[1] is None else left_cut[1].ovhg
         right_watson, right_crick = right_cut[0]
+        # TODO: this fills up nucleotides when it should not. It should either use the watson and crick
+        #      sequences as they are, or use the ovhg to shift the start or finish.
         return Dseq(
                     str(self[left_watson:right_watson]),
-                    _rc(str(self[left_crick:right_crick])),
+                    # The line below could be easier to understand as _rc(str(self[left_crick:right_crick])), but it does not preserve the case
+                    str(self.reverse_complement()[len(self) - right_crick:len(self) - left_crick]),
                     ovhg=ovhg,
                 )
 
@@ -1494,7 +1497,9 @@ class Dseq(_Seq):
         if len(cutsites) == 1 and self.circular:
             return [(cutsites[0], cutsites[0])]
         if not self.circular:
-            cutsites = [((0, 0), None), *cutsites, ((len(self), len(self)), None)]
+            left_edge = ((0 if self.ovhg < 0 else self.ovhg, 0 if self.ovhg < 0 else -self.ovhg), None)
+            right_edge = ((left_edge[0][0] + len(self.watson), left_edge[0][1] + len(self.crick)), None)
+            cutsites = [left_edge, *cutsites, right_edge]
         else:
             # Return in the same order as previous pydna versions
             cutsites = [cutsites[-1]] + cutsites[:-1]

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1448,7 +1448,7 @@ class Dseq(_Seq):
         return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)
 
     def get_cutsites(self, *enzymes):
-        """Returns a list of cutsites, represented by tuples ((cut_watson, cut_crick), enzyme).
+        """Returns a list of cutsites, represented by tuples ((cut_watson, cut_crick), enzyme), sorted by where they cut on the 5' strand.
 
         Parameters
         ----------
@@ -1459,7 +1459,16 @@ class Dseq(_Seq):
         -------
         list[tuple[tuple[int,int], _RestrictionType]]
 
-        TODO: check that the cutsite does not fall on the ovhg
+        Examples
+        --------
+
+        >>> from Bio.Restriction import EcoRI
+        >>> from pydna.dseq import Dseq
+        >>> seq = Dseq('AAGAATTCAAGAATTC')
+        >>> seq.get_cutsites(EcoRI)
+        [((3, 7), EcoRI), ((11, 15), EcoRI)]
+
+        TODO: check that the cutsite does not fall on the ovhg and that cutsites don't crash
         """
 
         if len(enzymes) == 1 and isinstance(enzymes[0], _RestrictionBatch):
@@ -1490,17 +1499,45 @@ class Dseq(_Seq):
                 )
 
     def get_cutsite_pairs(self, cutsites):
+        """ Pairs the cutsites 2 by 2 to render the edges of the resulting fragments.
+
+        Special cases:
+        - Single cutsite on circular sequence: returns a pair where both cutsites are the same
+        - Linear sequence:
+            - creates a new left_cut on the first pair to represent the left edge of the sequence as it is.
+            - creates a new right_cut on the last pair to represent the right edge of the sequence as it is.
+            - In both new cuts, the enzyme is set to None to indicate that the cut is not made by an enzyme.
+
+        Parameters
+        ----------
+        cutsites : list[tuple[tuple[int,int], _RestrictionType]]
+
+        Returns
+        -------
+        list[tuple[tuple[tuple[int,int], _RestrictionType]],tuple[tuple[int,int], _RestrictionType]]
+
+        Examples
+        --------
+
+        >>> from Bio.Restriction import EcoRI
+        >>> from pydna.dseq import Dseq
+        >>> seq = Dseq('AAGAATTCAAGAATTC')
+        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
+        [(((0, 0), None), ((3, 7), EcoRI)), (((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((16, 16), None))]
+        >>> seq = Dseq('AAGAATTCAAGAATTC', circular=True)
+        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
+        [(((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((3, 7), EcoRI))]
+        >>> seq = Dseq('AAGAATTCAA', circular=True)
+        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
+        [(((3, 7), EcoRI), ((3, 7), EcoRI))]
+        """
         if len(cutsites) == 0:
             return []
-        if len(cutsites) == 1 and self.circular:
-            return [(cutsites[0], cutsites[0])]
         if not self.circular:
             left_edge = ((self.ovhg, 0) if self.ovhg > 0 else (0, -self.ovhg), None)
             right_edge = ((left_edge[0][0] + len(self.watson), left_edge[0][1] + len(self.crick)), None)
             cutsites = [left_edge, *cutsites, right_edge]
         else:
-            # Return in the same order as previous pydna versions
-            # cutsites = [cutsites[-1]] + cutsites[:-1]
             # Add the first cutsite at the end, for circular cuts
             cutsites.append(cutsites[0])
 

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -1284,7 +1284,7 @@ class Dseqrecord(_SeqRecord):
         answer.seq = newseq
         return answer
 
-    def cut(self, *enzymes):
+    def cut2(self, *enzymes):
         """Digest a Dseqrecord object with one or more restriction enzymes.
 
         returns a list of linear Dseqrecords. If there are no cuts, an empty
@@ -1362,6 +1362,15 @@ class Dseqrecord(_SeqRecord):
             dsfs.append(dsf)
         return tuple(dsfs)
 
+    def apply_cut(self, left_cut, right_cut):
+        dseq = self.seq.apply_cut(left_cut, right_cut)
+        features = self[min(left_cut[0]):max(right_cut[0])].features
+        return Dseqrecord(dseq, features=features)
+
+    def cut(self, *enzymes):
+        cutsites = self.seq.get_cutsites(*enzymes)
+        cutsite_pairs = self.seq.get_cutsite_pairs(cutsites)
+        return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)
 
 if __name__ == "__main__":
     cache = _os.getenv("pydna_cache")

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -893,7 +893,12 @@ class Dseqrecord(_SeqRecord):
             answer.features = super().__getitem__(sl).features
         elif self.circular and sl_start > sl_stop:
             answer.features = self.shifted(sl_start).features
-            answer.features = [f for f in answer.features if f.location.parts[-1].end <= answer.seq.length]
+            # origin-spanning features should only be included after shifting
+            # in cases where the slice comprises the entire sequence, but then
+            # sl_start == sl_stop and the second condition is not met
+            answer.features = [f for f in answer.features if (
+                               f.location.parts[-1].end <= answer.seq.length and
+                               f.location.parts[0].start <= f.location.parts[-1].end)]
         else:
             answer = Dseqrecord("")
         identifier = "part_{id}".format(id=self.id)

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -1340,10 +1340,13 @@ class Dseqrecord(_SeqRecord):
         # TODO: maybe remove depending on https://github.com/BjornFJohansson/pydna/issues/161
 
         if left_cut == right_cut:
+            # Not really a cut, but to handle the general case
+            if left_cut is None:
+                features = self.features
             features = self.shifted(min(left_cut[0])).features
         else:
-            left_watson, left_crick = left_cut[0]
-            right_watson, right_crick = right_cut[0]
+            left_watson, left_crick = left_cut[0] if left_cut is not None else (0, 0)
+            right_watson, right_crick = right_cut[0] if right_cut is not None else (None, None)
 
             left_edge = left_crick if dseq.ovhg > 0 else left_watson
             right_edge = right_watson if dseq.watson_ovhg() > 0 else right_crick

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -1293,7 +1293,7 @@ class Dseqrecord(_SeqRecord):
         answer.seq = newseq
         return answer
 
-    def cut2(self, *enzymes):
+    def cut(self, *enzymes):
         """Digest a Dseqrecord object with one or more restriction enzymes.
 
         returns a list of linear Dseqrecords. If there are no cuts, an empty
@@ -1330,46 +1330,10 @@ class Dseqrecord(_SeqRecord):
 
 
         """
-        from pydna.utils import shift_location
 
-        features = _copy.deepcopy(self.features)
-
-        if self.circular:
-            try:
-                x, y, oh = self.seq._firstcut(*enzymes)
-            except ValueError:
-                return ()
-            dsr = _Dseq(
-                self.seq.watson[x:] + self.seq.watson[:x],
-                self.seq.crick[y:] + self.seq.crick[:y],
-                oh,
-            )
-            newstart = min(x, (self.seq.length - y))
-            for f in features:
-                f.location = shift_location(f.location, -newstart, self.seq.length)
-                f.location, *rest = f.location.parts
-                for part in rest:
-                    if 0 in part:
-                        f.location._end = part.end + self.seq.length
-                    else:
-                        f.location += part
-            frags = dsr.cut(enzymes) or [dsr]
-        else:
-            frags = self.seq.cut(enzymes)
-            if not frags:
-                return ()
-        dsfs = []
-        for fr in frags:
-            dsf = Dseqrecord(fr, n=self.n)
-            start = fr.pos
-            end = fr.pos + fr.length
-            dsf.features = [
-                _copy.deepcopy(fe) for fe in features if start <= fe.location.start and end >= fe.location.end
-            ]
-            for feature in dsf.features:
-                feature.location += -start
-            dsfs.append(dsf)
-        return tuple(dsfs)
+        cutsites = self.seq.get_cutsites(*enzymes)
+        cutsite_pairs = self.seq.get_cutsite_pairs(cutsites)
+        return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)
 
     def apply_cut(self, left_cut, right_cut):
         dseq = self.seq.apply_cut(left_cut, right_cut)
@@ -1386,11 +1350,6 @@ class Dseqrecord(_SeqRecord):
             features = self[left_edge:right_edge].features
 
         return Dseqrecord(dseq, features=features)
-
-    def cut(self, *enzymes):
-        cutsites = self.seq.get_cutsites(*enzymes)
-        cutsite_pairs = self.seq.get_cutsite_pairs(cutsites)
-        return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)
 
 if __name__ == "__main__":
     cache = _os.getenv("pydna_cache")

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -890,6 +890,10 @@ class Dseqrecord(_SeqRecord):
         sl_stop = sl.stop or len(self.seq)  # 1
 
         if not self.circular or sl_start < sl_stop:
+            # TODO: special case for sl_end == 0 in circular sequences
+            # related to https://github.com/BjornFJohansson/pydna/issues/161
+            if self.circular and sl.stop == 0:
+                sl = slice(sl.start, len(self.seq), sl.step)
             answer.features = super().__getitem__(sl).features
         elif self.circular and sl_start > sl_stop:
             answer.features = self.shifted(sl_start).features
@@ -1369,7 +1373,18 @@ class Dseqrecord(_SeqRecord):
 
     def apply_cut(self, left_cut, right_cut):
         dseq = self.seq.apply_cut(left_cut, right_cut)
-        features = self[min(left_cut[0]):max(right_cut[0])].features
+        # TODO: maybe remove depending on https://github.com/BjornFJohansson/pydna/issues/161
+
+        if left_cut == right_cut:
+            features = self.shifted(min(left_cut[0])).features
+        else:
+            left_watson, left_crick = left_cut[0]
+            right_watson, right_crick = right_cut[0]
+
+            left_edge = left_crick if dseq.ovhg > 0 else left_watson
+            right_edge = right_watson if dseq.watson_ovhg() > 0 else right_crick
+            features = self[left_edge:right_edge].features
+
         return Dseqrecord(dseq, features=features)
 
     def cut(self, *enzymes):

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -166,7 +166,6 @@ def test_cut_around_and_religate():
         if not frags:
             return
         a = frags.pop(0)
-        print(seq_string, enz, top)
 
         for f in frags:
             a += f
@@ -441,12 +440,6 @@ def test_dseq():
 
     frag1 = Dseq("G", "gatcc", 0)
     frag2 = Dseq("GATCCaaa", "g", -4)
-
-    print(obj.__repr__())
-    print(obj.cut(BamHI)[0].__repr__())
-    print(frag1.__repr__())
-    print(obj.cut(BamHI)[1].__repr__())
-    print(frag2.__repr__())
 
     assert obj.cut(BamHI) == (frag1, frag2)
 

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -62,7 +62,8 @@ def test_cut1():
 
     assert first + second + third + fourth == lds
 
-    assert (first.pos, second.pos, third.pos, fourth.pos) == (0, 4, 13, 22)
+    # TODO: remove
+    # assert (first.pos, second.pos, third.pos, fourth.pos) == (0, 4, 13, 22)
 
     frags2 = lds.cut((KpnI, ApaI, TaiI))
 
@@ -70,7 +71,8 @@ def test_cut1():
 
     assert first2 + second2 + third2 + fourth2 == lds
 
-    assert (first2.pos, second2.pos, third2.pos, fourth2.pos) == (0, 4, 13, 21)
+    # TODO: remove
+    # assert (first2.pos, second2.pos, third2.pos, fourth2.pos) == (0, 4, 13, 21)
 
 
 def test_cas9():
@@ -164,6 +166,8 @@ def test_cut_around_and_religate():
         if not frags:
             return
         a = frags.pop(0)
+        print(seq_string, enz, top)
+
         for f in frags:
             a += f
         if not top:

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -728,8 +728,8 @@ def test_misc():
     a, b = x.cut(NotI)
 
     z = (a + b).looped()
-
-    assert z.shifted(5) == x
+    # TODO: address this test change Related to https://github.com/BjornFJohansson/pydna/issues/78
+    assert z.shifted(-6) == x
 
 
 def test_cut_missing_enzyme():

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -551,12 +551,12 @@ def test_dseq():
     assert obj.cut(rb) == obj.cut(BamHI, BglII) == obj.cut(BglII, BamHI)
 
     obj = Dseq("ggatccAGATCT", circular=True)
-
-    assert obj.cut(rb) == obj.cut(BamHI, BglII) != obj.cut(BglII, BamHI)
+    # TODO: address this test change Related to https://github.com/BjornFJohansson/pydna/issues/78
+    assert obj.cut(rb) == obj.cut(BamHI, BglII) == obj.cut(BglII, BamHI)
 
     obj = Dseq("AGATCTggatcc", circular=True)
 
-    assert obj.cut(rb) == obj.cut(BglII, BamHI) != obj.cut(BamHI, BglII)
+    assert obj.cut(rb) == obj.cut(BglII, BamHI) == obj.cut(BamHI, BglII)
 
 
 def test_Dseq_slicing():
@@ -585,7 +585,7 @@ def test_Dseq_slicing2():
     from Bio.Restriction import BamHI, EcoRI, KpnI
 
     a = Dseq("aaGGATCCnnnnnnnnnGAATTCccc", circular=True)
-
+    # TODO: address this test change Related to https://github.com/BjornFJohansson/pydna/issues/78
     assert (
         a.cut(
             EcoRI,
@@ -596,7 +596,7 @@ def test_Dseq_slicing2():
             BamHI,
             EcoRI,
             KpnI,
-        )[::-1]
+        )
     )
 
 

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -442,6 +442,12 @@ def test_dseq():
     frag1 = Dseq("G", "gatcc", 0)
     frag2 = Dseq("GATCCaaa", "g", -4)
 
+    print(obj.__repr__())
+    print(obj.cut(BamHI)[0].__repr__())
+    print(frag1.__repr__())
+    print(obj.cut(BamHI)[1].__repr__())
+    print(frag2.__repr__())
+
     assert obj.cut(BamHI) == (frag1, frag2)
 
     assert frag1 + frag2 == obj

--- a/tests/test_module_dseqrecord.py
+++ b/tests/test_module_dseqrecord.py
@@ -1850,6 +1850,7 @@ def test__repr_pretty_():
 
 def test___getitem__():
     from pydna.dseqrecord import Dseqrecord
+    from Bio.SeqFeature import SeqFeature, SimpleLocation
 
     s = Dseqrecord("GGATCC", circular=False)
     assert s[1:-1].seq == Dseqrecord("GATC", circular=False).seq
@@ -1868,6 +1869,19 @@ def test___getitem__():
     assert t[9:10].seq == Dseqrecord("").seq
     assert t[10:9].seq == Dseqrecord("").seq
 
+    # Test how slicing works with features (using sequence as in test_features_change_ori)
+    seqRecord = Dseqrecord("aaagGTACCTTTGGATCcggg", circular=True)
+    f1 = SeqFeature(SimpleLocation(4, 17), type="misc_feature", strand=1)
+    f2 = SeqFeature(SimpleLocation(17, 21, 1) + SimpleLocation(0, 4), type="misc_feature", strand=1)
+    seqRecord.features = [f1, f2]
+
+    # Exact feature sliced for normal and origin-spanning features
+    assert len(seqRecord[4:17].features) == 1
+    assert len(seqRecord[17:4].features) == 1
+
+    # Partial feature sliced for normal and origin-spanning features
+    assert len(seqRecord[2:20].features) == 1
+    assert len(seqRecord[13:8].features) == 1
 
 def test___eq__():
     from pydna.dseqrecord import Dseqrecord

--- a/tests/test_module_dseqrecord.py
+++ b/tests/test_module_dseqrecord.py
@@ -807,6 +807,9 @@ def test_Dseqrecord_cutting_adding_2():
     for enz in enzymes:
         for f in a:
             b, c, d = f.cut(enz)
+            print(b.seq.__repr__())
+            print(c.seq.__repr__())
+            print(d.seq.__repr__())
             e = b + c + d
             assert str(e.seq).lower() == str(f.seq).lower()
 
@@ -1259,14 +1262,11 @@ def test_features_change_ori():
         """
 
         bb, ins = sorted(b.cut(Acc65I, BamHI), key=len, reverse=True)
-        # pytest -s -k test_features_change_ori tests/test_module_dseqrecord.py
-        print('>>>>>>', str(bb))
-        print()
-        print(ins)
+
         assert eq(bb1, bb)
         assert eq(ins1, ins)
 
-        assert bb.features[1].extract(bb).seq == bbfeat
+        assert bb.features[0].extract(bb).seq == bbfeat
         assert str(ins.features[0].extract(ins).seq) == str(insfeat)
 
 

--- a/tests/test_module_dseqrecord.py
+++ b/tests/test_module_dseqrecord.py
@@ -1259,11 +1259,14 @@ def test_features_change_ori():
         """
 
         bb, ins = sorted(b.cut(Acc65I, BamHI), key=len, reverse=True)
-
+        # pytest -s -k test_features_change_ori tests/test_module_dseqrecord.py
+        print('>>>>>>', str(bb))
+        print()
+        print(ins)
         assert eq(bb1, bb)
         assert eq(ins1, ins)
 
-        assert bb.features[0].extract(bb).seq == bbfeat
+        assert bb.features[1].extract(bb).seq == bbfeat
         assert str(ins.features[0].extract(ins).seq) == str(insfeat)
 
 
@@ -1630,7 +1633,7 @@ def test_figure():
     )
     assert b25.extract_feature(0).seq == feat
 
-
+@pytest.mark.xfail(reason="issue #78")
 def test_jan_glx():
     # Thanks to https://github.com/jan-glx
     from Bio.Restriction import NdeI, BamHI


### PR DESCRIPTION
Hi @BjornFJohansson here is an alternative implementation of the cutting functionality that follows what was mentioned in  #157.

It's a big one, so no problem if you take a while to review it. It decreases significantly the lines of code. The difference in total lines is a net positive, but I have removed only code, and added quite a bit of comments / docstrings. The current implementation uses more of the built-in biopython functionality, which currently supports searching for cutsites in circular molecules.

The function cut in `Dseq` is now splitted into three functions:

```python

cutsites = self.get_cutsites(*enzymes)
cutsite_pairs = self.get_cutsite_pairs(cutsites)
return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)

```
## get_cutsites

`get_cutsites` finds cutsites in the sequence,  returned as a list of `tuple[tuple[int,int], _RestrictionType]`, sorted by where they cut on the 5' strand.

For a given cutsite, e.g. `[(3, 7), EcoRI]`:
* The first position in the tuple (3) is the position where the enzyme will cut in the watson strand(same meaning as `enzyme.search() - 1` in biopython)
* The second position in the tuple (7) is the position where the enzyme will cut in the crick strand.
* EcoRI is the enzyme python object

```
>>> from Bio.Restriction import EcoRI
>>> from pydna.dseq import Dseq
>>> seq = Dseq('AAGAATTCAAGAATTC')
>>> seq.get_cutsites(EcoRI)
[((3, 7), EcoRI), ((11, 15), EcoRI)]
```

This is a convenient representation, and you can see why in the function `apply_cut`, where two such cuts are passed as inputs (ignore the two`if xxxx is not None` for now).

```python

def apply_cut(self, left_cut, right_cut):

        left_watson, left_crick = left_cut[0] if left_cut is not None else ((self.ovhg, 0) if self.ovhg > 0 else (0, -self.ovhg))
        ovhg = self.ovhg if left_cut is None else left_cut[1].ovhg
        right_watson, right_crick = right_cut[0] if right_cut is not None else (len(self.watson), len(self.crick))
        return Dseq(
                    str(self[left_watson:right_watson]),
                    # The line below could be easier to understand as _rc(str(self[left_crick:right_crick])), but it does not preserve the case
                    str(self.reverse_complement()[len(self) - right_crick:len(self) - left_crick]),
                    ovhg=ovhg,
                )
```

## get_cutsite_pairs

This pairs the cutsites 2 by 2 to render the edges of the resulting fragments.

```python
def get_cutsite_pairs(self, cutsites):
        """ Pairs the cutsites 2 by 2 to render the edges of the resulting fragments.

        Special cases:
        - Single cutsite on circular sequence: returns a pair where both cutsites are the same
        - Linear sequence:
            - creates a new left_cut on the first pair equal to `None` to represent the left edge of the sequence as it is.
            - creates a new right_cut on the last pair equal to `None` to represent the right edge of the sequence as it is.
            - In both new cuts, the enzyme is set to None to indicate that the cut is not made by an enzyme.

        Parameters
        ----------
        cutsites : list[tuple[tuple[int,int], _RestrictionType]]

        Returns
        -------
        list[tuple[tuple[tuple[int,int], _RestrictionType]|None],tuple[tuple[int,int], _RestrictionType]|None]

        Examples
        --------

        >>> from Bio.Restriction import EcoRI
        >>> from pydna.dseq import Dseq
        >>> seq = Dseq('AAGAATTCAAGAATTC')
        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
        [(None, ((3, 7), EcoRI)), (((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), None)]
        >>> seq = Dseq('AAGAATTCAAGAATTC', circular=True)
        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
        [(((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((3, 7), EcoRI))]
        >>> seq = Dseq('AAGAATTCAA', circular=True)
        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
        [(((3, 7), EcoRI), ((3, 7), EcoRI))]
        """
        if len(cutsites) == 0:
            return []
        if not self.circular:
            cutsites = [None, *cutsites, None]
        else:
            # Add the first cutsite at the end, for circular cuts
            cutsites.append(cutsites[0])

        return list(zip(cutsites, cutsites[1:]))
```

## apply_cut

Extracts a fragment from a sequence based on a pair of cuts, the code is above, and you can see now the case for when the enzyme is set to `None` (special case for the edges of a linear molecule).


## Extra things / thoughts

* The `pos` property of Dseq could be now removed

* `CutSite` could be made into a class with properties `cut_watson`, `cut_crick`, `enzyme` (would probably give more clarity).

* ~~The pairs at the edges could simply be `(None, ((3, 7), EcoRI))` instead of `(((0, 0), None), ((3, 7), EcoRI))`, perhaps clearer.~~ I ended up doing this, which I think is a bit clearer. With https://github.com/BjornFJohansson/pydna/pull/163/commits/0edcd200f576941f3534f1136e5daffe31c4de62

* The methods can be renamed, perhaps `cut_fragment` would be more clear?

* ~~I have added the dependency of `more_itertools`, for the function `pairwise`. This come with normal itertools in python 3.10, but not older versions.~~ Not anymore (https://github.com/BjornFJohansson/pydna/pull/163/commits/bf8aee2c1bf15ea674750cf9d9020e7d94cb04f7)

## Back compatibility

The only problem is that the cuts are returned in the same order regardless of the order of the input enzymes. I think this is a preferable behaviour, but I could make it back-compatible. I have modified some tests so that they test for the new behaviour, see `test_module_dseqrecord.py`, the line that says `@pytest.mark.xfail(reason="issue #78")`, and the lines in the test files that start with `# TODO:`, you can easily find them in the page of the diff of the PR.
