### PR TITLE
Update shift_location for origin-wrapping feature with strand None

### DIFF
--- a/src/pydna/utils.py
+++ b/src/pydna/utils.py
@@ -63,7 +63,7 @@ def shift_location(original_location, shift, lim):
             newparts.append(_sl(ns, ne, strand))
         else:
             parttuple = (_sl(ns, lim, strand), _sl(0, ne, strand))
-            newparts.extend(parttuple if strand == 1 else parttuple[::-1])
+            newparts.extend(parttuple if strand != -1 else parttuple[::-1])
     try:
         newloc = _cl(newparts)
     except ValueError:


### PR DESCRIPTION
Hi @BjornFJohansson I think this should be the expected behaviour (`strand = None` same as `strand = +1`). See the example below, for a feature that wraps around the origin in a molecule of length 12:

```python
from pydna.utils import shift_location
from Bio.SeqFeature import SimpleLocation


for strand in [None, 1, -1]:
    print('strand:', strand)
    print(shift_location(SimpleLocation(10, 14, strand), 0, 12))
    print()
```
Output is:

```
strand: None
join{[0:2], [10:12]}

strand: 1
join{[10:12](+), [0:2](+)}

strand: -1
join{[0:2](-), [10:12](-)}
```

I think for `strand == None` it should be `join{[10:12], [0:2]}` which more clearly shows the origin-wrapping nature of the feature.

The tests that fail are the same ones as before the change, so I don't think this breaks anything in the tests