### PR TITLE
Simpler cut representation

### DIFF
--- a/scripts/cutsite_pairs.ipynb
+++ b/scripts/cutsite_pairs.ipynb
@@ -4,40 +4,235 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# New cut implementation\n"
+    "# New cut implementation\n",
+    "\n",
+    "The most important thing is that cuts are now represented as `((cut_watson, ovhg), enz)`:\n",
+    "\n",
+    "- `cut_watson` is a positive integer contained in `[0,len(seq))`, where `seq` is the sequence that will be cut. It represents the position of the cut on the watson strand, using the full sequence as a reference. By \"full sequence\" I mean the one you would get from `str(Dseq)`. See example below.\n",
+    "- `ovhg` is the overhang left after the cut. It has the same meaning as `ovhg` in the `Bio.Restriction` enzyme objects, or pydna's `Dseq` property.\n",
+    "- `enz` is the enzyme object. It's not necessary to perform the cut, but can be used to keep track of which enzyme was used.\n",
+    "\n",
+    "The new implementation of `Dseq.cut` now looks like this:\n",
+    "\n",
+    "```python\n",
+    "cutsites = self.get_cutsites(*enzymes)\n",
+    "cutsite_pairs = self.get_cutsite_pairs(cutsites)\n",
+    "return tuple(self.apply_cut(*cs) for cs in cutsite_pairs)\n",
+    "```\n",
+    "\n",
+    "Let's go through it step by step"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "get_cutsites output: [((3, -4), EcoRI), ((11, -4), EcoRI)]\n",
+      "EcoRI.search output: [4, 12] < (positions are 1-based)\n",
+      "EcoRI.ovhg: -4\n",
+      "\n",
+      "get_cutsites output: [((6, -4), EcoRI)]\n",
+      "EcoRI.search output: [7] < (positions are 1-based)\n",
+      "EcoRI.ovhg: -4\n",
+      "\n",
+      "get_cutsites output: [((1, 2), PacI)]\n",
+      "PacI.search output: [2] < (positions are 1-based)\n",
+      "PacI.ovhg: 2\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pydna.dseq import Dseq\n",
+    "from Bio.Restriction import EcoRI, PacI\n",
+    "\n",
+    "dseq = Dseq('aaGAATTCaaGAATTCaa')\n",
+    "\n",
+    "# what this function does is basically handle the format of the enzymes, and return the cut positions\n",
+    "# that are returned by enz.search, along with the enzyme name and overhang. Positions are made zero-base\n",
+    "# instead of one-based\n",
+    "\n",
+    "print('get_cutsites output:', dseq.get_cutsites([EcoRI]))\n",
+    "print('EcoRI.search output:', EcoRI.search(dseq), '< (positions are 1-based)')\n",
+    "print('EcoRI.ovhg:', EcoRI.ovhg)\n",
+    "print()\n",
+    "\n",
+    "# Below are two examples of circular sequences with a cutsite that spans the origin.\n",
+    "dseq = Dseq('TTCaaGAA', circular=True)\n",
+    "print('get_cutsites output:', dseq.get_cutsites([EcoRI]))\n",
+    "print('EcoRI.search output:', EcoRI.search(dseq, linear=False), '< (positions are 1-based)')\n",
+    "print('EcoRI.ovhg:', EcoRI.ovhg)\n",
+    "print()\n",
+    "\n",
+    "dseq = Dseq('TTAAaaTTAA', circular=True)\n",
+    "print('get_cutsites output:', dseq.get_cutsites([PacI]))\n",
+    "print('PacI.search output:', PacI.search(dseq, linear=False), '< (positions are 1-based)')\n",
+    "print('PacI.ovhg:', PacI.ovhg)\n",
+    "print()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note how if the ovhg is negative, for an origin spanning cutsite, the position lies on the left side of the origin, and viceversa."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dseq(-10)\n",
+      "aaGAATTCaa\n",
+      " tCTTAAGtt\n",
+      "ovhg: -1 >> [((3, -4), EcoRI)]\n",
+      "\n",
+      "Dseq(-10)\n",
+      "aaGAATTCaa\n",
+      "ttCTTAAGtt\n",
+      "ovhg: 0 >> [((3, -4), EcoRI)]\n",
+      "\n",
+      "Dseq(-10)\n",
+      " aGAATTCaa\n",
+      "ttCTTAAGtt\n",
+      "ovhg: 1 >> [((3, -4), EcoRI)]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# `cut_watson` is defined with respect to the \"full sequence\"\n",
+    "for ovhg in [-1, 0, 1]:\n",
+    "    dseq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaa', ovhg, 0)\n",
+    "    print(dseq.__repr__())\n",
+    "    print('ovhg:', ovhg, '>>', dseq.get_cutsites([EcoRI]))\n",
+    "    print()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cuts are only returned if the recognition site and overhang are on the double-strand part\n",
+    "of the sequence. Not 100% sure if that's the \"right\" way to do it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Coming soon\n",
-    "# seq = Dseq('aaGAATTCaa', circular=True)\n",
-    "\n",
-    "# print('EcORI', EcoRI.ovhg, len(seq))\n",
-    "# for shift in range(len(seq)):\n",
-    "#     seq_shifted = seq.shifted(shift)\n",
-    "#     cut_site = seq_shifted.get_cutsites(EcoRI)[0][0]\n",
-    "#     print(shift, seq_shifted, cut_site, cut_site[0] - cut_site[1])\n",
-    "\n",
-    "# seq = Dseq('ccTTAATTAAcc', circular=True)\n",
-    "# print('PacI', PacI.ovhg, len(seq))\n",
-    "# for shift in range(len(seq)):\n",
-    "#     seq_shifted = seq.shifted(shift)\n",
-    "#     cut_site = seq_shifted.get_cutsites(PacI)[0][0]\n",
-    "#     print(shift, seq_shifted, cut_site, cut_site[0] - cut_site[1])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "\n",
-    "# seq = Dseq('TTAAccccTTAA', circular=True)\n",
-    "# custom_cut = ((1, 11), type('DynamicClass', (), {'ovhg': 2})())\n",
-    "# print(seq.apply_cut(custom_cut, custom_cut).__repr__())\n",
+    "## Pairing cutsites\n",
     "\n",
-    "# print()\n",
+    "A fragment produced by restriction is represented by a tuple of length two that may contain cutsites or `None`:\n",
     "\n",
-    "# custom_cut = ((1, 11), type('DynamicClass', (), {'ovhg': -10})())\n",
-    "# print(seq.apply_cut(custom_cut, custom_cut).__repr__())"
+    "- Two cutsites: represents the extraction of a fragment between those two cutsites, in that orientation. To represent the opening of a circular molecule with a single cutsite, we put the same cutsite twice. See below.\n",
+    "- `None`, cutsite: represents the extraction of a fragment between the left edge of linear sequence and the cutsite.\n",
+    "- cutsite, `None`: represents the extraction of a fragment between the cutsite and the right edge of a linear sequence.\n",
+    "\n",
+    "## Generating the sequence\n",
+    "\n",
+    "To get the fragment, we use the function `dseq.apply_cut`, passing the two elements of the tuple as arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> None, cutsite : (None, ((3, -4), EcoRI))\n",
+      "Dseq(-7)\n",
+      "aaG\n",
+      "ttCTTAA\n",
+      "\n",
+      "> cutsite, cutsite : (((3, -4), EcoRI), ((11, -4), EcoRI))\n",
+      "Dseq(-12)\n",
+      "AATTCaaG\n",
+      "    GttCTTAA\n",
+      "\n",
+      "> cutsite, None : (((11, -4), EcoRI), None)\n",
+      "Dseq(-7)\n",
+      "AATTCaa\n",
+      "    Gtt\n",
+      "\n",
+      "Circular molecule\n",
+      "> cutsite, cutsite : (((6, -4), EcoRI), ((6, -4), EcoRI))\n",
+      "Dseq(-12)\n",
+      "AATTCaaG\n",
+      "    GttCTTAA\n"
+     ]
+    }
+   ],
+   "source": [
+    "dseq = Dseq('aaGAATTCaaGAATTCaa')\n",
+    "cutsites = dseq.get_cutsites([EcoRI])\n",
+    "cutsite_pairs = dseq.get_cutsite_pairs(cutsites)\n",
+    "\n",
+    "pair_types = ['None, cutsite', 'cutsite, cutsite', 'cutsite, None']\n",
+    "\n",
+    "for pair, pair_type in zip(cutsite_pairs, pair_types):\n",
+    "    print('>', pair_type, ':',pair)\n",
+    "    print(dseq.apply_cut(*pair).__repr__())\n",
+    "    print()\n",
+    "\n",
+    "# Opening a circular sequence\n",
+    "print('Circular molecule')\n",
+    "dseq = Dseq('TTCaaGAA', circular=True)\n",
+    "cutsites = dseq.get_cutsites([EcoRI])\n",
+    "cutsite_pairs = dseq.get_cutsite_pairs(cutsites)\n",
+    "print('> cutsite, cutsite :', cutsite_pairs[0])\n",
+    "print(dseq.apply_cut(*cutsite_pairs[0]).__repr__())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dseq(-7)\n",
+      " aG\n",
+      "ttCTTAA\n",
+      "\n",
+      "Dseq(-7)\n",
+      "AATTCaa\n",
+      "    Gt\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Note that the cutsite respects the ovhg of the sequence:\n",
+    "dseq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaaGAATTCaa', 1, 1)\n",
+    "print(dseq.apply_cut(*cutsite_pairs[0]).__repr__())\n",
+    "print()\n",
+    "print(dseq.apply_cut(*cutsite_pairs[-1]).__repr__())\n"
    ]
   }
  ],
@@ -57,7 +252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/scripts/cutsite_pairs.ipynb
+++ b/scripts/cutsite_pairs.ipynb
@@ -80,12 +80,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note how if the ovhg is negative, for an origin spanning cutsite, the position lies on the left side of the origin, and viceversa."
+    "Note in the above printed output how if the ovhg is negative, for an origin spanning cutsite, the position lies on the left side of the origin, and viceversa.\n",
+    "\n",
+    "Below, you can see that the `cut_watson` is defined with respect to the \"full sequence\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -124,16 +126,30 @@
    "metadata": {},
    "source": [
     "Cuts are only returned if the recognition site and overhang are on the double-strand part\n",
-    "of the sequence. Not 100% sure if that's the \"right\" way to do it."
+    "of the sequence."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[((1, -4), EcoRI)]\n",
+      "[]\n"
+     ]
+    }
+   ],
    "source": [
-    "\n"
+    "\n",
+    "seq = Dseq('GAATTC')\n",
+    "print(seq.get_cutsites([EcoRI]))\n",
+    "\n",
+    "seq = Dseq.from_full_sequence_and_overhangs('GAATTC', -1, 0)\n",
+    "print(seq.get_cutsites([EcoRI]))"
    ]
   },
   {
@@ -144,7 +160,7 @@
     "\n",
     "## Pairing cutsites\n",
     "\n",
-    "A fragment produced by restriction is represented by a tuple of length two that may contain cutsites or `None`:\n",
+    "A fragment produced by restriction is represented by a tuple of length 2 that may contain cutsites or `None`:\n",
     "\n",
     "- Two cutsites: represents the extraction of a fragment between those two cutsites, in that orientation. To represent the opening of a circular molecule with a single cutsite, we put the same cutsite twice. See below.\n",
     "- `None`, cutsite: represents the extraction of a fragment between the left edge of linear sequence and the cutsite.\n",
@@ -157,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -190,8 +206,8 @@
    "source": [
     "dseq = Dseq('aaGAATTCaaGAATTCaa')\n",
     "cutsites = dseq.get_cutsites([EcoRI])\n",
-    "cutsite_pairs = dseq.get_cutsite_pairs(cutsites)\n",
     "\n",
+    "cutsite_pairs = dseq.get_cutsite_pairs(cutsites)\n",
     "pair_types = ['None, cutsite', 'cutsite, cutsite', 'cutsite, None']\n",
     "\n",
     "for pair, pair_type in zip(cutsite_pairs, pair_types):\n",
@@ -210,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -228,11 +244,12 @@
     }
    ],
    "source": [
-    "# Note that the cutsite respects the ovhg of the sequence:\n",
+    "# Note that the cutsite respects the ovhg of the parent sequence:\n",
     "dseq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaaGAATTCaa', 1, 1)\n",
-    "print(dseq.apply_cut(*cutsite_pairs[0]).__repr__())\n",
+    "f1, f2, f3 = dseq.cut([EcoRI])\n",
+    "print(f1.__repr__())\n",
     "print()\n",
-    "print(dseq.apply_cut(*cutsite_pairs[-1]).__repr__())\n"
+    "print(f3.__repr__())\n"
    ]
   }
  ],

--- a/scripts/cutsite_pairs.ipynb
+++ b/scripts/cutsite_pairs.ipynb
@@ -125,13 +125,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cuts are only returned if the recognition site and overhang are on the double-strand part\n",
-    "of the sequence."
+    "Cuts are only returned if the recognition site and overhang are on the double-strand part of the sequence."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {

--- a/scripts/cutsite_pairs.ipynb
+++ b/scripts/cutsite_pairs.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,8 +42,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1453,6 +1453,9 @@ class Dseq(_Seq):
         - Recognition site is not double stranded or is outside the sequence
         - For enzymes that cut twice, it checks that at least one possibility is valid
         """
+
+        assert cutsite != None, "cutsite is None"
+
         enz = cutsite[1]
         watson, crick, ovhg = self.get_cut_parameters(cutsite, True)
 
@@ -1492,7 +1495,18 @@ class Dseq(_Seq):
         return True
 
     def get_cutsites(self, *enzymes):
-        """Returns a list of cutsites, represented by tuples ((cut_watson, cut_crick), enzyme), sorted by where they cut on the 5' strand.
+        """Returns a list of cutsites, represented represented as `((cut_watson, ovhg), enz)`:
+
+        - `cut_watson` is a positive integer contained in `[0,len(seq))`, where `seq` is the sequence
+          that will be cut. It represents the position of the cut on the watson strand, using the full
+          sequence as a reference. By "full sequence" I mean the one you would get from `str(Dseq)`.
+        - `ovhg` is the overhang left after the cut. It has the same meaning as `ovhg` in
+          the `Bio.Restriction` enzyme objects, or pydna's `Dseq` property.
+        - `enz` is the enzyme object. It's not necessary to perform the cut, but can be
+           used to keep track of which enzyme was used.
+
+        Cuts are only returned if the recognition site and overhang are on the double-strand
+        part of the sequence.
 
         Parameters
         ----------
@@ -1510,9 +1524,27 @@ class Dseq(_Seq):
         >>> from pydna.dseq import Dseq
         >>> seq = Dseq('AAGAATTCAAGAATTC')
         >>> seq.get_cutsites(EcoRI)
-        [((3, 7), EcoRI), ((11, 15), EcoRI)]
+        [((3, -4), EcoRI), ((11, -4), EcoRI)]
 
-        TODO: check that the cutsite does not fall on the ovhg and that cutsites don't crash
+        `cut_watson` is defined with respect to the "full sequence", not the
+        watson strand:
+
+        >>> dseq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaa', 1, 0)
+        >>> dseq
+        Dseq(-10)
+         aGAATTCaa
+        ttCTTAAGtt
+        >>> dseq.get_cutsites([EcoRI])
+        [((3, -4), EcoRI)]
+
+        Cuts are only returned if the recognition site and overhang are on the double-strand
+        part of the sequence.
+
+        >>> Dseq('GAATTC').get_cutsites([EcoRI])
+        [((1, -4), EcoRI)]
+        >>> Dseq.from_full_sequence_and_overhangs('GAATTC', -1, 0).get_cutsites([EcoRI])
+        []
+
         """
 
         if len(enzymes) == 1 and isinstance(enzymes[0], _RestrictionBatch):
@@ -1531,9 +1563,9 @@ class Dseq(_Seq):
         return sorted([cutsite for cutsite in out if self.cutsite_is_valid(cutsite)])
 
     def left_end_position(self) -> tuple[int, int]:
-        """The index in the global sequence of the watson and crick start positions.
+        """The index in the full sequence of the watson and crick start positions.
 
-        Global sequence (str(self)) for all three cases is AAA
+        full sequence (str(self)) for all three cases is AAA
 
         ```
         AAA              AA               AAT
@@ -1547,9 +1579,9 @@ class Dseq(_Seq):
         return 0, -self.ovhg
 
     def right_end_position(self) -> tuple[int, int]:
-        """The index in the global sequence of the watson and crick end positions.
+        """The index in the full sequence of the watson and crick end positions.
 
-        Global sequence (str(self)) for all three cases is AAA
+        full sequence (str(self)) for all three cases is AAA
 
         ```
         AAA               AA                   AAA
@@ -1563,21 +1595,87 @@ class Dseq(_Seq):
         return len(self), len(self) - self.watson_ovhg()
 
     def get_cut_parameters(self, cut: tuple, is_left: bool):
-        """For a given cut expressed as ((watson_cut, ovhg), enz), returns
-        a tuple (watson_cut, crick_cut, ovhg). The cut can be None if it
-        represents the left or right end of the sequence. That's what the
-        is_left parameter is for."""
+        """For a given cut expressed as ((cut_watson, ovhg), enz), returns
+        a tuple (cut_watson, cut_crick, ovhg).
+
+        - cut_watson: see get_cutsites docs
+        - cut_crick: equivalent of cut_watson in the crick strand
+        - ovhg: see get_cutsites docs
+
+        The cut can be None if it represents the left or right end of the sequence.
+        Then it will return the position of the watson and crick ends with respect
+        to the "full sequence". The `is_left` parameter is only used in this case.
+
+        """
         if cut is not None:
             watson, ovhg = cut[0]
             crick = (watson - ovhg)
             if self.circular:
                 crick %= len(self)
             return watson, crick, ovhg
+
+        assert not self.circular, 'Circular sequences should not have None cuts'
+
         if is_left:
             return *self.left_end_position(), self.ovhg
-        return *self.right_end_position(), self.ovhg
+        # In the right end, the overhang does not matter
+        return *self.right_end_position(), None
 
     def apply_cut(self, left_cut, right_cut):
+        """Extracts a subfragment of the sequence between two cuts.
+
+        For more detail see the documentation of get_cutsite_pairs.
+
+        Parameters
+        ----------
+        left_cut : Union[tuple[tuple[int,int], _RestrictionType], None]
+        right_cut: Union[tuple[tuple[int,int], _RestrictionType], None]
+
+        Returns
+        -------
+        Dseq
+
+        Examples
+        --------
+        >>> from Bio.Restriction import EcoRI
+        >>> from pydna.dseq import Dseq
+        >>> dseq = Dseq('aaGAATTCaaGAATTCaa')
+        >>> cutsites = dseq.get_cutsites([EcoRI])
+        >>> cutsites
+        [((3, -4), EcoRI), ((11, -4), EcoRI)]
+        >>> p1, p2, p3 = dseq.get_cutsite_pairs(cutsites)
+        >>> p1
+        (None, ((3, -4), EcoRI))
+        >>> dseq.apply_cut(*p1)
+        Dseq(-7)
+        aaG
+        ttCTTAA
+        >>> p2
+        (((3, -4), EcoRI), ((11, -4), EcoRI))
+        >>> dseq.apply_cut(*p2)
+        Dseq(-12)
+        AATTCaaG
+            GttCTTAA
+        >>> p3
+        (((11, -4), EcoRI), None)
+        >>> dseq.apply_cut(*p3)
+        Dseq(-7)
+        AATTCaa
+            Gtt
+
+        >>> dseq = Dseq('TTCaaGAA', circular=True)
+        >>> cutsites = dseq.get_cutsites([EcoRI])
+        >>> cutsites
+        [((6, -4), EcoRI)]
+        >>> pair = dseq.get_cutsite_pairs(cutsites)[0]
+        >>> pair
+        (((6, -4), EcoRI), ((6, -4), EcoRI))
+        >>> dseq.apply_cut(*pair)
+        Dseq(-12)
+        AATTCaaG
+            GttCTTAA
+
+        """
         if _cuts_overlap(left_cut, right_cut, len(self)):
             raise ValueError("Cuts overlap")
 
@@ -1591,14 +1689,18 @@ class Dseq(_Seq):
                 )
 
     def get_cutsite_pairs(self, cutsites):
-        """ Pairs the cutsites 2 by 2 to render the edges of the resulting fragments.
+        """ Returns pairs of cutsites that render the edges of the resulting fragments.
 
-        Special cases:
-        - Single cutsite on circular sequence: returns a pair where both cutsites are the same
-        - Linear sequence:
-            - creates a new left_cut on the first pair equal to `None` to represent the left edge of the sequence as it is.
-            - creates a new right_cut on the last pair equal to `None` to represent the right edge of the sequence as it is.
-            - In both new cuts, the enzyme is set to None to indicate that the cut is not made by an enzyme.
+        A fragment produced by restriction is represented by a tuple of length 2 that
+        may contain cutsites or `None`:
+
+            - Two cutsites: represents the extraction of a fragment between those two
+              cutsites, in that orientation. To represent the opening of a circular
+              molecule with a single cutsite, we put the same cutsite twice.
+            - `None`, cutsite: represents the extraction of a fragment between the left
+              edge of linear sequence and the cutsite.
+            - cutsite, `None`: represents the extraction of a fragment between the cutsite
+              and the right edge of a linear sequence.
 
         Parameters
         ----------
@@ -1613,15 +1715,19 @@ class Dseq(_Seq):
 
         >>> from Bio.Restriction import EcoRI
         >>> from pydna.dseq import Dseq
-        >>> seq = Dseq('AAGAATTCAAGAATTC')
-        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
-        [(None, ((3, 7), EcoRI)), (((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), None)]
-        >>> seq = Dseq('AAGAATTCAAGAATTC', circular=True)
-        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
-        [(((3, 7), EcoRI), ((11, 15), EcoRI)), (((11, 15), EcoRI), ((3, 7), EcoRI))]
-        >>> seq = Dseq('AAGAATTCAA', circular=True)
-        >>> seq.get_cutsite_pairs(seq.get_cutsites(EcoRI))
-        [(((3, 7), EcoRI), ((3, 7), EcoRI))]
+        >>> dseq = Dseq('aaGAATTCaaGAATTCaa')
+        >>> cutsites = dseq.get_cutsites([EcoRI])
+        >>> cutsites
+        [((3, -4), EcoRI), ((11, -4), EcoRI)]
+        >>> dseq.get_cutsite_pairs(cutsites)
+        [(None, ((3, -4), EcoRI)), (((3, -4), EcoRI), ((11, -4), EcoRI)), (((11, -4), EcoRI), None)]
+
+        >>> dseq = Dseq('TTCaaGAA', circular=True)
+        >>> cutsites = dseq.get_cutsites([EcoRI])
+        >>> cutsites
+        [((6, -4), EcoRI)]
+        >>> dseq.get_cutsite_pairs(cutsites)
+        [(((6, -4), EcoRI), ((6, -4), EcoRI))]
         """
         if len(cutsites) == 0:
             return []

--- a/src/pydna/dseq.py
+++ b/src/pydna/dseq.py
@@ -1619,7 +1619,7 @@ class Dseq(_Seq):
         if is_left:
             return *self.left_end_position(), self.ovhg
         # In the right end, the overhang does not matter
-        return *self.right_end_position(), None
+        return *self.right_end_position(), self.watson_ovhg()
 
     def apply_cut(self, left_cut, right_cut):
         """Extracts a subfragment of the sequence between two cuts.

--- a/src/pydna/dseqrecord.py
+++ b/src/pydna/dseqrecord.py
@@ -1402,9 +1402,6 @@ class Dseqrecord(_SeqRecord):
             left_watson, left_crick, left_ovhg = self.seq.get_cut_parameters(left_cut, True)
             right_watson, right_crick, right_ovhg = self.seq.get_cut_parameters(right_cut, False)
 
-            # left_watson, left_crick = left_cut[0] if left_cut is not None else (0, 0)
-            # right_watson, right_crick = right_cut[0] if right_cut is not None else (None, None)
-
             left_edge = left_crick if left_ovhg > 0 else left_watson
             right_edge = right_watson if right_ovhg > 0 else right_crick
             features = self[left_edge:right_edge].features

--- a/src/pydna/utils.py
+++ b/src/pydna/utils.py
@@ -21,6 +21,7 @@ import keyword as _keyword
 import collections as _collections
 import itertools as _itertools
 from copy import deepcopy as _deepcopy
+from typing import Union as _Union
 
 import sys as _sys
 import re
@@ -816,10 +817,11 @@ def cuts_overlap(left_cut, right_cut, seq_len):
 
     # This block of code would not be necessary if the cuts were
     # initially represented like this
-    (left_watson, _), enz1 = left_cut
-    (right_watson, _), enz2 = right_cut
-    left_crick = left_watson - enz1.ovhg
-    right_crick = right_watson - enz2.ovhg
+    (left_watson, left_ovhg), _ = left_cut
+    (right_watson, right_ovhg), _ = right_cut
+    # Position of the cut on the crick strands on the left and right
+    left_crick = left_watson - left_ovhg
+    right_crick = right_watson - right_ovhg
     if left_crick >= seq_len:
         left_crick -= seq_len
         left_watson -= seq_len
@@ -832,7 +834,7 @@ def cuts_overlap(left_cut, right_cut, seq_len):
     y = sorted([right_watson, right_crick])
     return (x[1] > y[0]) != (y[1] < x[0])
 
-def location_boundaries(loc: _sl|_cl):
+def location_boundaries(loc: _Union[_sl,_cl]):
 
     #TODO: pending on https://github.com/BjornFJohansson/pydna/pull/179
     if loc.strand != 1:

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -825,7 +825,7 @@ def test_apply_cut():
     assert seq.apply_cut(None, None) == seq
 
     # A cut where one side is None leaves that side intact
-    EcoRI_cut = ((3, 7), type('DynamicClass', (), {'ovhg': -4})())
+    EcoRI_cut = ((3, -4), None)
     assert seq.apply_cut(None, EcoRI_cut) == Dseq.from_full_sequence_and_overhangs('aaGAATT', watson_ovhg=-4, crick_ovhg=0)
     assert seq.apply_cut(EcoRI_cut, None) == Dseq.from_full_sequence_and_overhangs('AATTCaa', watson_ovhg=0, crick_ovhg=-4)
 
@@ -844,28 +844,28 @@ def test_apply_cut():
 
     # Two cuts extract a subsequence
     seq = Dseq('aaGAATTCaaGAATTCaa', circular=True)
-    EcoRI_cut_2 = ((11, 15), type('DynamicClass', (), {'ovhg': -4})())
+    EcoRI_cut_2 = ((11, -4), None)
     assert seq.apply_cut(EcoRI_cut, EcoRI_cut_2) == Dseq.from_full_sequence_and_overhangs('AATTCaaGAATT', watson_ovhg=-4, crick_ovhg=-4)
 
     # Overlapping cuts should return an error
     seq = Dseq('aaGAATTCaa', circular=True)
     first_cuts = [
-        ((3, 7), type('DynamicClass', (), {'ovhg': -4})()),
-        ((7, 3), type('DynamicClass', (), {'ovhg': 4})()),
+        ((3, -4), None),
+        ((7, 4), None),
         # Spanning the origin
-        ((9, 8), type('DynamicClass', (), {'ovhg': -8})()),
-        ((8, 9), type('DynamicClass', (), {'ovhg': 8})()),
+        ((9, -8), None),
+        ((8, 8), None),
         ]
     overlapping_cuts = [
-        ((4, 8), type('DynamicClass', (), {'ovhg': -4})()),
-        ((2, 6), type('DynamicClass', (), {'ovhg': -4})()),
-        ((2, 8), type('DynamicClass', (), {'ovhg': -4})()),
-        ((8, 4), type('DynamicClass', (), {'ovhg': 4})()),
-        ((6, 2), type('DynamicClass', (), {'ovhg': 4})()),
-        ((8, 2), type('DynamicClass', (), {'ovhg': 4})()),
+        ((4, -4), None),
+        ((2, -4), None),
+        ((2, -6), None),
+        ((8, 4), None),
+        ((6, 4), None),
+        ((8, 6), None),
         # Spanning the origin
-        ((7, 6), type('DynamicClass', (), {'ovhg': -8})()),
-        ((6, 7), type('DynamicClass', (), {'ovhg': 8})()),
+        ((7, -8), None),
+        ((6, 8), None),
     ]
 
     for first_cut in first_cuts:

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -976,7 +976,7 @@ def test_get_cut_parameters():
 
     dseq = Dseq.from_full_sequence_and_overhangs('aaaACGTaaa', 3, 3)
     assert dseq.get_cut_parameters(None, True) == (*dseq.left_end_position(), dseq.ovhg)
-    assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), None)
+    assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), dseq.watson_ovhg())
 
     assert dseq.get_cut_parameters(((4, -2), None), True) == (4, 6, -2)
     assert dseq.get_cut_parameters(((4, -2), None), False) == (4, 6, -2)
@@ -994,7 +994,7 @@ def test_get_cut_parameters():
         assert False, 'Expected AssertionError'
 
     try:
-        assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), None)
+        assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), dseq.watson_ovhg())
     except AssertionError as e:
         assert e.args[0] == 'Circular sequences should not have None cuts'
     else:

--- a/tests/test_module_dseqrecord.py
+++ b/tests/test_module_dseqrecord.py
@@ -2243,8 +2243,7 @@ def test_apply_cut():
 
     # Single cut case
     for strand in [1, -1, None]:
-        for cut_coords, cut_ovhg in (((4, 7), -3), ((7, 4), 3)):
-            dummy_cut = (cut_coords, type('DynamicClass', (), {'ovhg': cut_ovhg})())
+        for dummy_cut in (((4, -3), None), ((7, 3), None)):
             seq = Dseqrecord("acgtATGaatt", circular=True)
             seq.features.append(SeqFeature(SimpleLocation(4, 7,  strand), id='full_overlap'))
             seq.features.append(SeqFeature(SimpleLocation(3, 7,  strand), id='left_side'))


### PR DESCRIPTION
@BjornFJohansson this implements a simpler version of the cut, described in detail in the notebook `scripts/cutsite_pairs.ipynb`. It stores the position of the cut on the watson strand + the overhang of the resulting cut.