### PR TITLE
Typing of dseq

### DIFF
--- a/src/pydna/common_sub_strings.py
+++ b/src/pydna/common_sub_strings.py
@@ -16,7 +16,9 @@ the original code was covered by an MIT licence."""
 # from array import array as _array
 # import itertools as _itertools
 from operator import itemgetter as _itemgetter
+from typing import List as _List, Tuple as _Tuple
 
+Match = _Tuple[int, int, int]
 
 # def _kark_sort(s, SA, n, K):
 #     def radixpass(a, b, r, s, n, k):
@@ -312,16 +314,37 @@ from operator import itemgetter as _itemgetter
 #     return match
 
 
-def common_sub_strings(stringx: str, stringy: str, limit=25):
+def common_sub_strings(stringx: str, stringy: str, limit=25) -> _List[Match]:
+    """
+    Finds all common substrings between stringx and stringy, and returns
+    them sorted by length.
+
+    This function is case sensitive.
+
+    Parameters
+    ----------
+    stringx : str
+    stringy : str
+    limit : int, optional
+
+    Returns
+    -------
+    list of tuple
+        [(startx1, starty1, length1),(startx2, starty2, length2), ...]
+
+        startx1 = startposition in x, where substring 1 starts
+        starty1 = position in y where substring 1 starts
+        length1 = lenght of substring
+    """
     from pydivsufsort import common_substrings
 
-    match = common_substrings(stringx, stringy, limit=limit)
-    match.sort()
-    match.sort(key=_itemgetter(2), reverse=True)
-    return match
+    matches = common_substrings(stringx, stringy, limit=limit)
+    matches.sort()
+    matches.sort(key=_itemgetter(2), reverse=True)
+    return matches
 
 
-def terminal_overlap(stringx: str, stringy: str, limit=15):
+def terminal_overlap(stringx: str, stringy: str, limit=15) -> _List[Match]:
     """Finds the the flanking common substrings between stringx and stringy
     longer than limit. This means that the results only contains substrings
     that starts or ends at the the ends of stringx and stringy.

--- a/src/pydna/utils.py
+++ b/src/pydna/utils.py
@@ -19,11 +19,8 @@ import keyword as _keyword
 import collections as _collections
 import itertools as _itertools
 from copy import deepcopy as _deepcopy
-from typing import Union as _Union
 
 import sys as _sys
-import re
-import itertools
 import random
 import subprocess as _subprocess
 from bisect import bisect as _bisect
@@ -34,6 +31,11 @@ from pydna.codon import rare_codons as _rare_codons
 
 from Bio.SeqFeature import SimpleLocation as _sl
 from Bio.SeqFeature import CompoundLocation as _cl
+
+from typing import Union as _Union, TypeVar as _TypeVar, List as _List
+
+# For functions that take str or bytes as input and return str or bytes as output, matching the input type
+StrOrBytes = _TypeVar("StrOrBytes", str, bytes)
 
 _module_logger = _logging.getLogger("pydna." + __name__)
 _ambiguous_dna_complement.update({"U": "A"})
@@ -256,7 +258,7 @@ def open_folder(pth):
             return "no cache to open."
 
 
-def rc(sequence: str):
+def rc(sequence: StrOrBytes) -> StrOrBytes:
     """Reverse complement.
 
     accepts mixed DNA/RNA
@@ -332,7 +334,7 @@ def identifier_from_string(s: str) -> str:
     return s
 
 
-def flatten(*args):
+def flatten(*args) -> _List:
     """Flattens an iterable of iterables.
 
     Down to str, bytes, bytearray or any of the pydna or Biopython seq objects

--- a/tests/test_module_dseq.py
+++ b/tests/test_module_dseq.py
@@ -719,6 +719,19 @@ def test_shifted():
     assert a.shifted(0) is not a
 
 
+def test_looped():
+
+    # Looping a circular sequence should return a copy of the sequence
+    # not the same sequence
+
+    from pydna.dseq import Dseq
+
+    a = Dseq("gatc", circular=True)
+
+    assert a.looped() == a
+    assert a.looped() is not a
+
+
 def test_misc():
     from pydna.dseq import Dseq
 
@@ -829,7 +842,7 @@ def test_apply_cut():
     from pydna.dseq import Dseq
     from Bio.Restriction import EcoRI, BamHI
 
-    seq = Dseq('aaGAATTCaa', circular=False)
+    seq = Dseq("aaGAATTCaa", circular=False)
 
     # A cut where both sides are None returns the same sequence
     assert seq.apply_cut(None, None) == seq
@@ -838,44 +851,44 @@ def test_apply_cut():
     EcoRI_cut = ((3, -4), None)
 
     assert seq.apply_cut(None, EcoRI_cut) == Dseq.from_full_sequence_and_overhangs(
-        'aaGAATT', watson_ovhg=-4, crick_ovhg=0
+        "aaGAATT", watson_ovhg=-4, crick_ovhg=0
     )
     assert seq.apply_cut(EcoRI_cut, None) == Dseq.from_full_sequence_and_overhangs(
-        'AATTCaa', watson_ovhg=0, crick_ovhg=-4
+        "AATTCaa", watson_ovhg=0, crick_ovhg=-4
     )
 
     # It respects the original overhang
-    seq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaa', watson_ovhg=1, crick_ovhg=1)
+    seq = Dseq.from_full_sequence_and_overhangs("aaGAATTCaa", watson_ovhg=1, crick_ovhg=1)
     assert seq.apply_cut(None, EcoRI_cut) == Dseq.from_full_sequence_and_overhangs(
-        'aaGAATT', watson_ovhg=-4, crick_ovhg=1
+        "aaGAATT", watson_ovhg=-4, crick_ovhg=1
     )
     assert seq.apply_cut(EcoRI_cut, None) == Dseq.from_full_sequence_and_overhangs(
-        'AATTCaa', watson_ovhg=1, crick_ovhg=-4
+        "AATTCaa", watson_ovhg=1, crick_ovhg=-4
     )
 
-    seq = Dseq.from_full_sequence_and_overhangs('aaGAATTCaa', watson_ovhg=-1, crick_ovhg=-1)
+    seq = Dseq.from_full_sequence_and_overhangs("aaGAATTCaa", watson_ovhg=-1, crick_ovhg=-1)
     assert seq.apply_cut(None, EcoRI_cut) == Dseq.from_full_sequence_and_overhangs(
-        'aaGAATT', watson_ovhg=-4, crick_ovhg=-1
+        "aaGAATT", watson_ovhg=-4, crick_ovhg=-1
     )
     assert seq.apply_cut(EcoRI_cut, None) == Dseq.from_full_sequence_and_overhangs(
-        'AATTCaa', watson_ovhg=-1, crick_ovhg=-4
+        "AATTCaa", watson_ovhg=-1, crick_ovhg=-4
     )
 
     # A repeated cut in a circular molecule opens it up
-    seq = Dseq('aaGAATTCaa', circular=True)
+    seq = Dseq("aaGAATTCaa", circular=True)
     assert seq.apply_cut(EcoRI_cut, EcoRI_cut) == Dseq.from_full_sequence_and_overhangs(
-        'AATTCaaaaGAATT', watson_ovhg=-4, crick_ovhg=-4
+        "AATTCaaaaGAATT", watson_ovhg=-4, crick_ovhg=-4
     )
 
     # Two cuts extract a subsequence
-    seq = Dseq('aaGAATTCaaGAATTCaa', circular=True)
+    seq = Dseq("aaGAATTCaaGAATTCaa", circular=True)
     EcoRI_cut_2 = ((11, -4), None)
     assert seq.apply_cut(EcoRI_cut, EcoRI_cut_2) == Dseq.from_full_sequence_and_overhangs(
-        'AATTCaaGAATT', watson_ovhg=-4, crick_ovhg=-4
+        "AATTCaaGAATT", watson_ovhg=-4, crick_ovhg=-4
     )
 
     # Overlapping cuts should return an error
-    seq = Dseq('aaGAATTCaa', circular=True)
+    seq = Dseq("aaGAATTCaa", circular=True)
     first_cuts = [
         ((3, -4), BamHI),
         ((7, 4), BamHI),
@@ -901,13 +914,13 @@ def test_apply_cut():
             try:
                 seq.apply_cut(first_cut, second_cut)
             except ValueError as e:
-                assert e.args[0] == 'Cuts by BamHI EcoRI overlap.'
+                assert e.args[0] == "Cuts by BamHI EcoRI overlap."
             else:
                 print(first_cut, second_cut)
-                assert False, 'Expected ValueError'
+                assert False, "Expected ValueError"
 
     # Rotating the sequence, apply the same cut
-    seq = Dseq('acgtATGaatt', circular=True)
+    seq = Dseq("acgtATGaatt", circular=True)
     for shift in range(len(seq)):
         seq_shifted = seq.shifted(shift)
         start = 4 - shift
@@ -916,19 +929,19 @@ def test_apply_cut():
         # Cut with negative ovhg
         new_cut = ((start, -3), None)
         out = seq_shifted.apply_cut(new_cut, new_cut)
-        assert str(out) == 'ATGaattacgtATG'
+        assert str(out) == "ATGaattacgtATG"
 
         # Cut with positive ovhg
         start = (start + 3) % len(seq)
         new_cut = ((start, 3), None)
         out = seq_shifted.apply_cut(new_cut, new_cut)
-        assert str(out) == 'ATGaattacgtATG'
+        assert str(out) == "ATGaattacgtATG"
 
         # A blunt cut
         start = 4 - shift
         new_cut = ((start, 0), None)
         out = seq_shifted.apply_cut(new_cut, new_cut)
-        assert str(out) == 'ATGaattacgt'
+        assert str(out) == "ATGaattacgt"
 
 
 def test_cutsite_is_valid():
@@ -964,7 +977,7 @@ def test_cutsite_is_valid():
                 assert len(dseq.get_cutsites([enz])) == 1
 
     # Special cases:
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 0, 0)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 0, 0)
     assert len(dseq.get_cutsites([NmeDI])) == 2
     # Remove left cutting place
     assert len(dseq[2:].get_cutsites([NmeDI])) == 1
@@ -974,27 +987,27 @@ def test_cutsite_is_valid():
     assert len(dseq[2:-2].get_cutsites([NmeDI])) == 0
 
     # overhang left side
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', -2, 0)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", -2, 0)
     assert len(dseq.get_cutsites([NmeDI])) == 1
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 2, 0)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 2, 0)
     assert len(dseq.get_cutsites([NmeDI])) == 1
 
     # overhang right side
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 0, 2)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 0, 2)
     assert len(dseq.get_cutsites([NmeDI])) == 1
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 0, -2)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 0, -2)
     assert len(dseq.get_cutsites([NmeDI])) == 1
 
     # overhang both sides
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 2, 2)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 2, 2)
     assert len(dseq.get_cutsites([NmeDI])) == 0
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', -2, -2)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", -2, -2)
     assert len(dseq.get_cutsites([NmeDI])) == 0
 
     # overhang on recognition site removes both cutting places
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 16, 0)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 16, 0)
     assert len(dseq.get_cutsites([NmeDI])) == 0
-    dseq = Dseq.from_full_sequence_and_overhangs('AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA', 0, 16)
+    dseq = Dseq.from_full_sequence_and_overhangs("AAAAAAAAAAAAAGCCGGCAAAAAAAAAAAA", 0, 16)
     assert len(dseq.get_cutsites([NmeDI])) == 0
 
 
@@ -1003,7 +1016,7 @@ def test_get_cutsite_pairs():
 
     # in the test, we replace cuts by integers for clarity.
 
-    dseq = Dseq('A')
+    dseq = Dseq("A")
 
     # Empty returns empty list
     assert dseq.get_cutsite_pairs([]) == []
@@ -1014,7 +1027,7 @@ def test_get_cutsite_pairs():
     # Two cuts on linear seq return three fragments
     assert dseq.get_cutsite_pairs([1, 2]) == [(None, 1), (1, 2), (2, None)]
 
-    dseq = Dseq('A', circular=True)
+    dseq = Dseq("A", circular=True)
 
     # Empty returns empty list
     assert dseq.get_cutsite_pairs([]) == []
@@ -1030,7 +1043,7 @@ def test_get_cut_parameters():
 
     from pydna.dseq import Dseq
 
-    dseq = Dseq.from_full_sequence_and_overhangs('aaaACGTaaa', 3, 3)
+    dseq = Dseq.from_full_sequence_and_overhangs("aaaACGTaaa", 3, 3)
     assert dseq.get_cut_parameters(None, True) == (*dseq.left_end_position(), dseq.ovhg)
     assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), dseq.watson_ovhg())
 
@@ -1039,22 +1052,22 @@ def test_get_cut_parameters():
     assert dseq.get_cut_parameters(((6, 2), None), True) == (6, 4, 2)
     assert dseq.get_cut_parameters(((6, 2), None), False) == (6, 4, 2)
 
-    dseq = Dseq('aaaACGTaaa', circular=True)
+    dseq = Dseq("aaaACGTaaa", circular=True)
 
     # None cannot be used on circular molecules
     try:
         assert dseq.get_cut_parameters(None, True) == (*dseq.left_end_position(), dseq.ovhg)
     except AssertionError as e:
-        assert e.args[0] == 'Circular sequences should not have None cuts'
+        assert e.args[0] == "Circular sequences should not have None cuts"
     else:
-        assert False, 'Expected AssertionError'
+        assert False, "Expected AssertionError"
 
     try:
         assert dseq.get_cut_parameters(None, False) == (*dseq.right_end_position(), dseq.watson_ovhg())
     except AssertionError as e:
-        assert e.args[0] == 'Circular sequences should not have None cuts'
+        assert e.args[0] == "Circular sequences should not have None cuts"
     else:
-        assert False, 'Expected AssertionError'
+        assert False, "Expected AssertionError"
 
     # "Normal" cuts
     assert dseq.get_cut_parameters(((4, -2), None), True) == (4, 6, -2)


### PR DESCRIPTION
Hi @JeffXiePL, this is an example of what you could do for including typing for a module. I have also included some extra small changes beyond indicating the types of arguments and function returns, but you don't really have to do that unless you spot something that you think needs changing.

Have a look at the files changed of this PR to see my changes.

Note the usage of `TypeVar`. This is useful when you want to use the same class method for a class and subclass, and the method returns that same class or subclass as output. Below is a silly minimal example that you can test in vscode:

```python
from typing import TypeVar

T = TypeVar("T")

class myParentClass():
    def __init__(self, name: str):
        self.name = name

    def with_name_suffix(self: T, other_name: str) -> T:
        return self.__class__(other_name)

class myChildClass(myParentClass):
    def __init__(self, name: str):
        super().__init__(name)

parent = myParentClass("parent")
child = myChildClass("child")

parent2 = parent.with_name_suffix("parent2")
child2 = child.with_name_suffix("child2")
```

If you hold `cmd` and hover over `parent2` and `child2`, you will see that the type displayed is the correct one. This is also the case if you omit the typing entirely, because vscode can infer it for this code, but it's not always the case depending on which functions are used in the body of the method, so we can be explicit and indicate it.
